### PR TITLE
Use direct URL to avoid intermittenet errors with redirected URL

### DIFF
--- a/Detection-Rules/UndocumentedRMM.kusto
+++ b/Detection-Rules/UndocumentedRMM.kusto
@@ -9,7 +9,7 @@ let ApprovedRMM = datatable(Software:string, DeviceSubstring:string) [
 ];
 //------------------------------------------------------------------
 let RMMCatalogue = materialize(
-    (externaldata(response: string) [@"https://github.com/0x706972686f/RMM-Catalogue/raw/main/rmm.csv"] with (format="txt"))
+    (externaldata(response: string) [@"https://raw.githubusercontent.com/0x706972686f/RMM-Catalogue/main/rmm.csv"] with (format="txt"))
     | where response !startswith "Software"
     | project response
     | extend data = parse_csv(response)


### PR DESCRIPTION
Was using this in Sentinel and kept getting `Some aspects of the query had errors so the results are not complete`. After some debugging I realised it didn't like the 302 ~90% of the time 🤷‍♂️.

Using the direct URL works flawlessly